### PR TITLE
fix: error handling.

### DIFF
--- a/change-website-lang/background.js
+++ b/change-website-lang/background.js
@@ -39,6 +39,9 @@ function setScrollOffset(tabId, offset) {
 
 async function changeCurrentTab(offset) {
   const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (tabs.length === 0) {
+    return;
+  }
   const replacementUrl = getReplacementUrl(tabs[0].url);
 
   if (replacementUrl) {
@@ -80,15 +83,17 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
 });
 
 const extensionIconClickListener = (tab) => {
-  chrome.scripting.executeScript(
-    {
+  chrome.scripting
+    .executeScript({
       target: { tabId: tab.id },
       func: () => window.pageYOffset,
-    },
-    (injectionResults) => {
+    })
+    .then((injectionResults) => {
       changeCurrentTab(injectionResults[0].result);
-    },
-  );
+    })
+    .catch((error) => {
+      console.log('Error executing script: ', error);
+    });
 };
 
 chrome.action.onClicked.addListener(extensionIconClickListener);


### PR DESCRIPTION
- #6 
- #7 

main issue here is that chrome.scripting.executeScript() call might not always succeed. Specifically, it fails when the URL of the tab is a chrome:// URL, because extensions aren't allowed to inject scripts into these pages.

Additionally, chrome.scripting.executeScript() returns a Promise, and when the Promise is rejected, an error is thrown. This error will not be caught unless a catch() block is added to the Promise chain.

Lastly, I see an issue with the changeCurrentTab function where it attempts to read tabs[0].url. If tabs array is empty (which is possible if the query did not match any currently open tabs), then tabs[0] will be undefined and trying to access the url property of undefined will throw a TypeError.

In extensionIconClickListener, I added a .catch() block to handle any errors that might occur when the promise returned by chrome.scripting.executeScript() is rejected.

In changeCurrentTab, I added a check to ensure that tabs[0] exists before trying to access its url property. This will prevent a TypeError from being thrown if no tabs matched the query.