### PR TITLE
feat: add options page to set target site and locale

### DIFF
--- a/change-website-lang/manifest.json
+++ b/change-website-lang/manifest.json
@@ -6,6 +6,7 @@
   "background": {
     "service_worker": "background.js"
   },
+  "options_page": "options.html",
   "permissions": [
     "activeTab",
     "scripting",
@@ -13,8 +14,8 @@
     "storage"
   ],
   "host_permissions": [
-    "https://learn.microsoft.com/*",
-    "https://docs.github.com/*"
+    "https://*/*",
+    "http://*/*"
   ],
   "action": {
     "default_title": "Change languages"

--- a/change-website-lang/options.html
+++ b/change-website-lang/options.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Extension Options</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        margin: 0;
+        padding: 0;
+        background-color: #f9f9f9;
+        color: #333;
+      }
+      h1 {
+        background-color: #4c8bf5;
+        color: #fff;
+        padding: 10px 20px;
+        margin: 0;
+        font-size: 20px;
+      }
+      p {
+        padding: 10px 20px;
+        line-height: 1.6;
+      }
+      textarea {
+        width: 100%;
+        padding: 10px;
+        margin: 10px 0;
+        box-sizing: border-box;
+      }
+      button {
+        background-color: #4c8bf5;
+        color: #fff;
+        padding: 10px 20px;
+        border: none;
+        cursor: pointer;
+        margin: 0 20px;
+        border-radius: 3px;
+      }
+      button:hover {
+        background-color: #3b7cd3;
+      }
+      #saveMessage {
+        color: green;
+        padding: 0 20px;
+      }
+      .textarea-container {
+        padding: 0 20px 10px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Options setting</h1>
+    <p>
+      Enter the root URLs and two corresponding locales that you wish to toggle
+      between.
+      <br />
+      Example: <b>https://learn.microsoft.com, en-us, ja-jp</b>
+      <br />
+      In this case, any URL starting with https://learn.microsoft.com will
+      switch between the en-us and ja-jp locales.
+      <br />
+      Please ensure to separate each URL and locale pair with a comma and each
+      pair should be on a new line.
+    </p>
+    <div class="textarea-container">
+      <textarea id="targetInfo" rows="10"></textarea>
+    </div>
+    <button id="saveButton">Save</button>
+    <p id="saveMessage"></p>
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/change-website-lang/options.js
+++ b/change-website-lang/options.js
@@ -1,0 +1,41 @@
+// Update the TARGET_INFO in the background page
+function updateBackgroundPage() {
+  const backgroundPage = chrome.extension.getBackgroundPage();
+  backgroundPage.updateTargetInfo();
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+  // Gets the target info from chrome.storage
+  chrome.storage.local.get(['target_info'], function (result) {
+    if (result.target_info) {
+      document.getElementById('targetInfo').value = result.target_info;
+    }
+  });
+
+  // Event listener for the save button
+  document.getElementById('saveButton').addEventListener('click', () => {
+    const targetInfo = document.getElementById('targetInfo').value;
+    chrome.storage.local.set({ target_info: targetInfo }, function () {
+      // Display a message to the user indicating that the data has been saved.
+      displaySaveMessage();
+
+      // Update the TARGET_INFO in the background page
+      updateBackgroundPage();
+    });
+  });
+});
+
+// Display a message indicating when the mappings were last saved.
+function displaySaveMessage() {
+  const saveMessage = document.getElementById('saveMessage');
+  const now = new Date();
+  const timestamp = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(
+    2,
+    '0',
+  )}-${String(now.getDate()).padStart(2, '0')} ${String(
+    now.getHours(),
+  ).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}:${String(
+    now.getSeconds(),
+  ).padStart(2, '0')}`;
+  saveMessage.textContent = `Saved at ${timestamp}`;
+}


### PR DESCRIPTION
- #5 

This commit introduces several improvements to the extension, notably enabling the user to dynamically configure target URLs and associated locale mappings. 

Details:

1. Created an options page that allows users to define target URL settings and locale mappings.
2. The options page saves these settings into Chrome's local storage.
3. The background script is updated to fetch target information from Chrome's local storage.
4. Implemented the necessary mechanisms to keep the target info up-to-date in the background script whenever user changes the settings from the options page.
5. Improved error handling and code organization.