### PR TITLE
fix: Modify updateTargetInfo

### DIFF
--- a/change-website-lang/background.js
+++ b/change-website-lang/background.js
@@ -101,3 +101,9 @@ const extensionIconClickListener = (tab) => {
 };
 
 chrome.action.onClicked.addListener(extensionIconClickListener);
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.command === 'updateTargetInfo') {
+    updateTargetInfo();
+  }
+});

--- a/change-website-lang/options.js
+++ b/change-website-lang/options.js
@@ -1,7 +1,6 @@
 // Update the TARGET_INFO in the background page
 function updateBackgroundPage() {
-  const backgroundPage = chrome.extension.getBackgroundPage();
-  backgroundPage.updateTargetInfo();
+  chrome.runtime.sendMessage({ command: 'updateTargetInfo' });
 }
 
 document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
## Issue ticket number and link
- fix #12 

## Describe your changes

The solution involves modifying the communication method between the options page and the background script.

- Using chrome.runtime.sendMessage to send an 'updateTargetInfo' command from the options page.
- Implementing a message listener in the background script to trigger the updateTargetInfo() function when the message is received.
These changes ensure the background script's TARGET_INFO remains up-to-date with Chrome storage, allowing correct processing of newly added URLs.
