### PR TITLE
avoid chrome:// access error, add comments, Beta AWS docs local change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # change-website-lang
 
+## Notice
+- Beta: Locale in AWS document <https://docs.aws.amazon.com> is changed from english to japanese. Before start, set the locale of the doc page to English. (hard coded as `const langCode = 'ja_jp';`)
+
 ## About
 - Chrome extension for quickly switching between two locales on any given website.
 - The scroll position is retained when switching between locales.

--- a/change-website-lang/options.html
+++ b/change-website-lang/options.html
@@ -51,6 +51,9 @@
   <body>
     <h1>Options setting</h1>
     <p>
+      Beta: Locale in AWS document <https://docs.aws.amazon.com> is changed from
+      english to japanese. Before start, set the locale of the doc page to
+      English. (hard coded as `const langCode = 'ja_jp';`)<br />---- <br />
       Enter the root URLs and two corresponding locales that you wish to toggle
       between.
       <br />


### PR DESCRIPTION
## Issue ticket number and link
- #15 

## Describe your changes

- Beta: AWS docs locale change is on by default now. Only for `ja_jp`: Hard coded in background.js as `const langCode = 'ja_jp';`
